### PR TITLE
Patch methods in followerSubsystem to handle follower inversion

### DIFF
--- a/src/main/java/com/aembot/lib/subsystems/base/MotorFollowerSubsystem.java
+++ b/src/main/java/com/aembot/lib/subsystems/base/MotorFollowerSubsystem.java
@@ -107,16 +107,16 @@ public class MotorFollowerSubsystem<
    */
   @Override
   public double getCurrentPosition() {
-    double positionSum = inputs.positionUnits;
+    double uninvertedPositionSum = inputs.positionUnits;
     for (int i = 0; i < followerMotorInputs.length; i++) {
       double followerPosition = followerMotorInputs[i].positionUnits;
       // If follower is inverted, negate its position to align with leader
       if (mainConfig.followerConfigurations.get(i).followDirection == FollowDirection.INVERT) {
         followerPosition = -followerPosition;
       }
-      positionSum += followerPosition;
+      uninvertedPositionSum += followerPosition;
     }
-    return positionSum / (mainConfig.followerConfigurations.size() + 1);
+    return uninvertedPositionSum / (mainConfig.followerConfigurations.size() + 1);
   }
 
   /**


### PR DESCRIPTION
Previously, positions / velocities from different motors would cancel each other out if any of the followers were inverted. Change getCurrentPosition and getCurrentVelocity methods to take inversion into account